### PR TITLE
Adding Try/Except catch for KeyError on API call missing data

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@
         <div class="card">
             
                 
-                    <iframe width="420" height="315" src="https://www.youtube.com/embed/XCjTwALse0Q" ></iframe>
+                    <iframe width="420" height="315" src="https://www.youtube.com/embed/tyICpAPiuLU" ></iframe>
                 
-                <h2>Kid Cudi</h2>
-                <p>REVOFEV</p>
+                <h2>Abafana Baka Molo</h2>
+                <p>Ungaz' Ungibulale</p>
             
             <div class="share-container">
                 <!-- Social Media Share button -->
@@ -52,49 +52,44 @@
             <h3>Choose where to listen</h3>
             <div class="grid-icons">
                 
-                    <a href="https://www.youtube.com/watch?v=XCjTwALse0Q" target="_blank" title="youtube">
+                    <a href="https://www.youtube.com/watch?v=tyICpAPiuLU" target="_blank" title="youtube">
                         <img src="/static/icons/youtube.svg" alt="youtube icon"/>
                         <p>YouTube</p>
                     </a>
                 
-                    <a href="https://music.youtube.com/watch?v=XCjTwALse0Q" target="_blank" title="youtubeMusic">
+                    <a href="https://music.youtube.com/watch?v=tyICpAPiuLU" target="_blank" title="youtubeMusic">
                         <img src="/static/icons/youtubemusic.svg" alt="youtubeMusic icon"/>
                         <p>YouTube Music</p>
                     </a>
                 
-                    <a href="https://geo.music.apple.com/ca/album/_/1452877009?i=1452877303&mt=1&app=music&ls=1&at=1000lHKX&ct=api_http&itscg=30200&itsct=odsl_m" target="_blank" title="appleMusic">
+                    <a href="https://geo.music.apple.com/ca/album/_/667983494?i=667983500&mt=1&app=music&ls=1&at=1000lHKX&ct=api_http&itscg=30200&itsct=odsl_m" target="_blank" title="appleMusic">
                         <img src="/static/icons/applemusic.svg" alt="appleMusic icon"/>
                         <p>Apple Music</p>
                     </a>
                 
-                    <a href="https://open.spotify.com/track/0Epl79nHvdyTdZRAiWpJah" target="_blank" title="spotify">
+                    <a href="https://open.spotify.com/track/4ukiw01ClouyaFvyxIDyK7" target="_blank" title="spotify">
                         <img src="/static/icons/spotify.svg" alt="spotify icon"/>
                         <p>Spotify</p>
                     </a>
                 
-                    <a href="https://www.pandora.com/TR:1601650" target="_blank" title="pandora">
-                        <img src="/static/icons/pandora.svg" alt="pandora icon"/>
-                        <p>Pandora</p>
-                    </a>
-                
-                    <a href="https://www.deezer.com/track/7521055" target="_blank" title="deezer">
+                    <a href="https://www.deezer.com/track/87250537" target="_blank" title="deezer">
                         <img src="/static/icons/deezer.svg" alt="deezer icon"/>
                         <p>Deezer</p>
                     </a>
                 
-                    <a href="https://soundcloud.com/cudderland/revofev-album-version?utm_medium=api&utm_campaign=social_sharing&utm_source=id_314547" target="_blank" title="soundcloud">
-                        <img src="/static/icons/soundcloud.svg" alt="soundcloud icon"/>
-                        <p>SoundCloud</p>
-                    </a>
-                
-                    <a href="https://music.amazon.com/albums/B004AS3WV2?trackAsin=B004ARWBOW" target="_blank" title="amazonMusic">
+                    <a href="https://music.amazon.com/albums/B00GD4HHXA?trackAsin=B00GD4HJQ0" target="_blank" title="amazonMusic">
                         <img src="/static/icons/amazonmusic.svg" alt="amazonMusic icon"/>
                         <p>Amazon Music</p>
                     </a>
                 
-                    <a href="https://listen.tidal.com/track/4734459" target="_blank" title="tidal">
+                    <a href="https://listen.tidal.com/track/38249638" target="_blank" title="tidal">
                         <img src="/static/icons/tidal.svg" alt="tidal icon"/>
                         <p>Tidal</p>
+                    </a>
+                
+                    <a href="https://audiomack.com/song/abafana-baka-molo/ungaz-ungibulale" target="_blank" title="audiomack">
+                        <img src="/static/icons/audiomack.svg" alt="audiomack icon"/>
+                        <p>Audiomack</p>
                     </a>
                 
             </div>

--- a/scripts/youtube_randomizer.py
+++ b/scripts/youtube_randomizer.py
@@ -83,26 +83,36 @@ class RandomGenerator():
             {"key": "audiomack", "label": "Audiomack", "icon": "audiomack.svg"},
         ]
     
-        # Filter only services that exist in the API response
         links = []
-        for s in services:
-            link = data["linksByPlatform"].get(s["key"], {}).get("url")
-            if link:
-                links.append({**s, "url": link})
+        try:
+            # Attempt to use the linksByPlatform data from the songlink API response
+            # Filter only services that exist in the API response
+            for s in services:
+                link = data["linksByPlatform"].get(s["key"], {}).get("url")
+                if link:
+                    links.append({**s, "url": link})
     
-        # Thumbnail fallback (Spotify → Amazon → YouTube Music)
-        entities = data["entitiesByUniqueId"]
-        thumbnail = None
-        if "spotify" in data["linksByPlatform"]:
-            uid = data["linksByPlatform"]["spotify"]["entityUniqueId"]
-            thumbnail = entities.get(uid, {}).get("thumbnailUrl")
-        if not thumbnail and "amazonMusic" in data["linksByPlatform"]:
-            uid = data["linksByPlatform"]["amazonMusic"]["entityUniqueId"]
-            thumbnail = entities.get(uid, {}).get("thumbnailUrl")
-        if not thumbnail:
+            # Thumbnail fallback (Spotify → Amazon → YouTube Music)
+            entities = data["entitiesByUniqueId"]
+            thumbnail = None
+            if "spotify" in data["linksByPlatform"]:
+                uid = data["linksByPlatform"]["spotify"]["entityUniqueId"]
+                thumbnail = entities.get(uid, {}).get("thumbnailUrl")
+            if not thumbnail and "amazonMusic" in data["linksByPlatform"]:
+                uid = data["linksByPlatform"]["amazonMusic"]["entityUniqueId"]
+                thumbnail = entities.get(uid, {}).get("thumbnailUrl")
+            if not thumbnail:
+                thumbnail = self.random_result["thumbnails"][-1]["url"]
+
+        except KeyError:
+            # linksByPlatform data is missing from the songlink API response
+            # Default to using the YouTube API URL and Thumbnail data
+            links.append({**services[0], "url": self.random_result.get("YT_embed")})
+            links.append({**services[1], "url": self.random_result.get("YT_url")})
             thumbnail = self.random_result["thumbnails"][-1]["url"]
 
         self.random_result.update({"links": links, "thumbnail": thumbnail})
+
 
     def write_to_db(self):
         ''' pull out the data we need for our DB record and write it to the DB '''


### PR DESCRIPTION
When the linksByPlatform key is missing from the Songlink API call response data default to using the existing YTMusicAPI video and song URLs, plus the YT Music Thumbnail data.